### PR TITLE
feat/ARE-218: Add are-servcice & update istio versions

### DIFF
--- a/are/active-versions.yaml
+++ b/are/active-versions.yaml
@@ -1,27 +1,57 @@
-service-demo:
+are-gateway:
   main:
-    version: 1.0.0
+    version: 0.1.1
     weight: 100
   canary: {}
   deployment-strategy: canary
   enabled: true
+are-notification-processing-service:
+  main:
+    version: 0.1.2
+    weight: 100
+  canary: {}
+  deployment-strategy: canary
+  enabled: true
+validation-service-are:
+  main:
+    version: 2.10.1
+    weight: 100
+  canary: {}
+  synchronize-profiles: false
+  chart-name: validation-service
+  deployment-strategy: canary
+  enabled: true
+are-profile-snapshots:
+  main:
+    version: 1.0.1
+    weight: 100
+  canary: {}
+  deployment-strategy: update
+  enabled: true
 policies-authentications:
   main:
-    version: 2.4.0
+    version: 2.9.0
     weight: 100
   canary: {}
   deployment-strategy: update
   enabled: true
 policies-authorizations:
   main:
-    version: 2.4.0
+    version: 2.9.0
     weight: 100
   canary: {}
   deployment-strategy: update
   enabled: true
+portal-are:
+  main:
+    version: 0.1.0
+    weight: 100
+  canary: {}
+  deployment-strategy: canary
+  enabled: true
 istio-routing:
   main:
-    version: 1.2.0
+    version: 1.3.0
     weight: 100
   canary: {}
   deployment-strategy: update

--- a/are/active-versions.yaml
+++ b/are/active-versions.yaml
@@ -30,14 +30,14 @@ are-profile-snapshots:
   enabled: true
 policies-authentications:
   main:
-    version: 2.9.0
+    version: 2.8.1
     weight: 100
   canary: {}
   deployment-strategy: update
   enabled: true
 policies-authorizations:
   main:
-    version: 2.9.0
+    version: 2.8.1
     weight: 100
   canary: {}
   deployment-strategy: update
@@ -51,7 +51,7 @@ portal-are:
   enabled: true
 istio-routing:
   main:
-    version: 1.3.0
+    version: 1.3.1
     weight: 100
   canary: {}
   deployment-strategy: update

--- a/are/active-versions.yaml
+++ b/are/active-versions.yaml
@@ -1,13 +1,13 @@
 are-gateway:
   main:
-    version: 0.1.1
+    version: 0.1.2
     weight: 100
   canary: {}
   deployment-strategy: canary
   enabled: true
 are-notification-processing-service:
   main:
-    version: 0.1.2
+    version: 0.1.3
     weight: 100
   canary: {}
   deployment-strategy: canary
@@ -44,7 +44,7 @@ policies-authorizations:
   enabled: true
 portal-are:
   main:
-    version: 0.1.0
+    version: 0.1.1
     weight: 100
   canary: {}
   deployment-strategy: canary

--- a/are/application-configuration.tfvars
+++ b/are/application-configuration.tfvars
@@ -14,5 +14,7 @@ docker_registry = "docker.io/gematik1"
 kubeconfig_path = "../infrastructure/kind-config"
 # Flag to enable/disable the configuration of remote debugging for the Java Services
 debug_enabled = true
+# Settings for validation service profile provisioning mode. Possible values are: dedicated, distributed, combined
+profile_provisioning_mode_vs_igs = "dedicated"
 
 volumes = {}

--- a/are/application-configuration.tfvars
+++ b/are/application-configuration.tfvars
@@ -15,6 +15,6 @@ kubeconfig_path = "../infrastructure/kind-config"
 # Flag to enable/disable the configuration of remote debugging for the Java Services
 debug_enabled = true
 # Settings for validation service profile provisioning mode. Possible values are: dedicated, distributed, combined
-profile_provisioning_mode_vs_igs = "dedicated"
+profile_provisioning_mode_vs_are = "dedicated"
 
 volumes = {}

--- a/are/feature_flags.tfvars
+++ b/are/feature_flags.tfvars
@@ -1,2 +1,8 @@
 # Map containing the Feature Flags to be activated for services
-feature_flags = []
+feature_flags = [
+  {
+    services   = ["portal-are"]
+    flag_name  = "FEATURE_FLAG_NEW_API_ENDPOINTS"
+    flag_value = true
+  }
+]

--- a/are/feature_flags.tfvars
+++ b/are/feature_flags.tfvars
@@ -1,8 +1,2 @@
 # Map containing the Feature Flags to be activated for services
-feature_flags = [
-  {
-    services   = ["portal-are"]
-    flag_name  = "FEATURE_FLAG_NEW_API_ENDPOINTS"
-    flag_value = true
-  }
-]
+feature_flags = []

--- a/are/policies-authorizations/istio-values.tftpl.yaml
+++ b/are/policies-authorizations/istio-values.tftpl.yaml
@@ -1,7 +1,7 @@
 # If active, as default all traffic is denied
 allowNothing: true
 
-ekmTemplate:
+are:
   enabled: true
 
 postgres:
@@ -20,3 +20,5 @@ tcp:
   principals:
     enabled: true
 
+featureFlags:
+  newApiEndpoints: ${feature_flag_new_api_endpoints}

--- a/are/policies-authorizations/istio-values.tftpl.yaml
+++ b/are/policies-authorizations/istio-values.tftpl.yaml
@@ -19,6 +19,3 @@ demis:
 tcp:
   principals:
     enabled: true
-
-featureFlags:
-  newApiEndpoints: ${feature_flag_new_api_endpoints}

--- a/are/resources.tfvars
+++ b/are/resources.tfvars
@@ -1,7 +1,19 @@
 # Map containing the Resources Definitions to be defined for the Services in the cluster
 resource_definitions = [
   {
-    service  = "service-demo"
+    service  = "are-gateway"
+    replicas = 1
+  },
+  {
+    service  = "are-notification-processing-service"
+    replicas = 1
+  },
+  {
+    service  = "portal-are"
+    replicas = 1
+  },
+  {
+    service  = "validation-service-are"
     replicas = 1
   }
 ]


### PR DESCRIPTION
- Add portal-are, are-gateway, are-notification-processing-servive and validation-service-are in active-versions & resources.tfvars
- Add feature flag to disable portal-are
- Update version of policies-authentications and policies-authorizations to 2.9.0